### PR TITLE
Translate log messages to English

### DIFF
--- a/src/cli/commands/help.rs
+++ b/src/cli/commands/help.rs
@@ -5,64 +5,64 @@ pub fn show_help() {
     let program_name = env::args()
         .next()
         .unwrap_or_else(|| "shortlinker".to_string());
-    println!("{}", "shortlinker - 短链接管理工具".bold().magenta());
+    println!("{}", "shortlinker - URL shortening tool".bold().magenta());
     println!();
-    println!("{}", "用法:".bold());
+    println!("{}", "Usage:".bold());
     println!(
-        "  {}                          # 启动服务器",
+        "  {}                          # start server",
         program_name.cyan()
     );
     println!(
-        "  {} start                    # 启动服务器",
+        "  {} start                    # start server",
         program_name.cyan()
     );
     println!(
-        "  {} stop                     # 停止服务器",
+        "  {} stop                     # stop server",
         program_name.cyan()
     );
     println!(
-        "  {} restart                  # 重启服务器",
+        "  {} restart                  # restart server",
         program_name.cyan()
     );
     println!(
-        "  {} help                     # 显示帮助信息",
-        program_name.cyan()
-    );
-    println!();
-    println!("{}", "链接管理:".bold());
-    println!(
-        "  {} add <短码> <目标URL> [选项]   # 添加短链接",
-        program_name.cyan()
-    );
-    println!(
-        "  {} add <目标URL> [选项]         # 使用随机短码添加",
-        program_name.cyan()
-    );
-    println!(
-        "  {} update <短码> <目标URL> [选项] # 更新现有短链接",
-        program_name.cyan()
-    );
-    println!(
-        "  {} remove <短码>              # 删除短链接",
-        program_name.cyan()
-    );
-    println!(
-        "  {} list                      # 列出所有短链接",
-        program_name.cyan()
-    );
-    println!(
-        "  {} export [文件路径]           # 导出短链接为JSON",
-        program_name.cyan()
-    );
-    println!(
-        "  {} import <文件路径> [选项]     # 从JSON导入短链接",
+        "  {} help                     # show help",
         program_name.cyan()
     );
     println!();
-    println!("{}", "选项:".bold());
-    println!("  {}     强制覆盖已存在的短码", "--force".yellow());
+    println!("{}", "Link management:".bold());
     println!(
-        "  {}    设置过期时间 (RFC3339格式或相对时间)",
+        "  {} add <code> <target URL> [options]   # add short link",
+        program_name.cyan()
+    );
+    println!(
+        "  {} add <target URL> [options]         # add with random code",
+        program_name.cyan()
+    );
+    println!(
+        "  {} update <code> <target URL> [options] # update existing link",
+        program_name.cyan()
+    );
+    println!(
+        "  {} remove <code>              # remove short link",
+        program_name.cyan()
+    );
+    println!(
+        "  {} list                      # list all short links",
+        program_name.cyan()
+    );
+    println!(
+        "  {} export [file path]           # export links as JSON",
+        program_name.cyan()
+    );
+    println!(
+        "  {} import <file path> [options]     # import links from JSON",
+        program_name.cyan()
+    );
+    println!();
+    println!("{}", "Options:".bold());
+    println!("  {}     force overwrite existing code", "--force".yellow());
+    println!(
+        "  {}    set expiration (RFC3339 or relative time)",
         "--expire".yellow()
     );
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -37,7 +37,7 @@ impl From<crate::errors::ShortlinkerError> for CliError {
 
 pub async fn run_cli() {
     if let Err(e) = run_cli_inner().await {
-        println!("{} {}", "错误:".bold().red(), e);
+        println!("{} {}", "Error:".bold().red(), e);
         process::exit(1);
     }
 }

--- a/src/cli/process_manager.rs
+++ b/src/cli/process_manager.rs
@@ -5,7 +5,7 @@ pub struct ProcessManager;
 
 impl ProcessManager {
     pub fn start_server() -> Result<(), CliError> {
-        println!("{} 正在启动 shortlinker 服务器...", "ℹ".bold().blue());
+        println!("{} Starting shortlinker server...", "ℹ".bold().blue());
 
         #[cfg(unix)]
         {
@@ -23,17 +23,17 @@ impl ProcessManager {
 
                             if signal::kill(Pid::from_raw(old_pid as i32), None).is_ok() {
                                 println!(
-                                    "{} 服务器已在运行 (PID: {})",
+                                    "{} Server already running (PID: {})",
                                     "⚠".bold().yellow(),
                                     old_pid
                                 );
                                 println!(
-                                    "{} 如需重启，请先使用 'stop' 命令停止服务器",
+                                    "{} To restart, first use the 'stop' command",
                                     "ℹ".bold().blue()
                                 );
                                 return Ok(());
                             } else {
-                                println!("{} 清理孤立的 PID 文件...", "ℹ".bold().blue());
+                                println!("{} Cleaning up stale PID file...", "ℹ".bold().blue());
                                 let _ = fs::remove_file(pid_file);
                             }
                         }
@@ -44,9 +44,9 @@ impl ProcessManager {
                 }
             }
 
-            println!("{} 使用以下命令启动服务器:", "ℹ".bold().blue());
+            println!("{} Start the server with:", "ℹ".bold().blue());
             println!("  {}", "./shortlinker".cyan());
-            println!("{} 或在后台运行:", "ℹ".bold().blue());
+            println!("{} Or run in the background:", "ℹ".bold().blue());
             println!(
                 "  {}",
                 "nohup ./shortlinker > shortlinker.log 2>&1 &".cyan()
@@ -60,17 +60,17 @@ impl ProcessManager {
             let lock_file = ".shortlinker.lock";
 
             if Path::new(lock_file).exists() {
-                println!("{} 服务器可能已在运行", "⚠".bold().yellow());
+                println!("{} Server may already be running", "⚠".bold().yellow());
                 println!(
-                    "{} 如确认服务器未运行，请删除锁文件: {}",
+                    "{} If the server is not running, delete the lock file: {}",
                     "ℹ".bold().blue(),
                     lock_file
                 );
-                println!("{} 然后重新启动服务器", "ℹ".bold().blue());
+                println!("{} Then restart the server", "ℹ".bold().blue());
                 return Ok(());
             }
 
-            println!("{} 使用以下命令启动服务器:", "ℹ".bold().blue());
+            println!("{} Start the server with:", "ℹ".bold().blue());
             println!("  {}", "shortlinker.exe".cyan());
         }
 
@@ -78,7 +78,7 @@ impl ProcessManager {
     }
 
     pub fn stop_server() -> Result<(), CliError> {
-        println!("{} 正在停止 shortlinker 服务器...", "ℹ".bold().blue());
+        println!("{} Stopping shortlinker server...", "ℹ".bold().blue());
 
         #[cfg(unix)]
         {
@@ -88,7 +88,7 @@ impl ProcessManager {
             let pid_file = "shortlinker.pid";
 
             if !Path::new(pid_file).exists() {
-                println!("{} 未找到 PID 文件，服务器可能未运行", "⚠".bold().yellow());
+                println!("{} PID file not found, server may not be running", "⚠".bold().yellow());
                 return Ok(());
             }
 
@@ -101,7 +101,7 @@ impl ProcessManager {
                         let server_pid = Pid::from_raw(pid as i32);
 
                         if signal::kill(server_pid, None).is_err() {
-                            println!("{} 进程 {} 不存在，清理 PID 文件", "⚠".bold().yellow(), pid);
+                            println!("{} Process {} not found, cleaning PID file", "⚠".bold().yellow(), pid);
                             let _ = fs::remove_file(pid_file);
                             return Ok(());
                         }
@@ -109,7 +109,7 @@ impl ProcessManager {
                         match signal::kill(server_pid, Signal::SIGTERM) {
                             Ok(_) => {
                                 println!(
-                                    "{} 已向服务器进程 {} 发送停止信号",
+                                    "{} Sent stop signal to server process {}",
                                     "✓".bold().green(),
                                     pid
                                 );
@@ -118,12 +118,12 @@ impl ProcessManager {
 
                                 if signal::kill(server_pid, None).is_ok() {
                                     println!(
-                                        "{} 服务器进程仍在运行，尝试强制终止...",
+                                        "{} Server process still running, trying to force kill...",
                                         "⚠".bold().yellow()
                                     );
                                     match signal::kill(server_pid, Signal::SIGKILL) {
                                         Ok(_) => {
-                                            println!("{} 服务器已强制停止", "✓".bold().green())
+                                            println!("{} Server force stopped", "✓".bold().green())
                                         }
                                         Err(e) => {
                                             return Err(CliError::ProcessError(format!(
@@ -133,24 +133,24 @@ impl ProcessManager {
                                         }
                                     }
                                 } else {
-                                    println!("{} 服务器已正常停止", "✓".bold().green());
+                                    println!("{} Server stopped gracefully", "✓".bold().green());
                                 }
 
                                 let _ = fs::remove_file(pid_file);
                             }
                             Err(e) => {
                                 return Err(CliError::ProcessError(format!(
-                                    "无法停止服务器进程: {}",
+                                    "Failed to stop server process: {}",
                                     e
                                 )));
                             }
                         }
                     } else {
-                        return Err(CliError::ProcessError("PID 文件格式无效".to_string()));
+                        return Err(CliError::ProcessError("Invalid PID file format".to_string()));
                     }
                 }
                 Err(e) => {
-                    return Err(CliError::ProcessError(format!("无法读取 PID 文件: {}", e)));
+                    return Err(CliError::ProcessError(format!("Failed to read PID file: {}", e)));
                 }
             }
         }
@@ -162,18 +162,18 @@ impl ProcessManager {
             let lock_file = ".shortlinker.lock";
 
             if !Path::new(lock_file).exists() {
-                println!("{} 未找到锁文件，服务器可能未运行", "⚠".bold().yellow());
+                println!("{} Lock file not found, server may not be running", "⚠".bold().yellow());
                 return Ok(());
             }
 
-            println!("{} Windows 平台不支持自动停止服务器", "⚠".bold().yellow());
+            println!("{} Windows does not support automatic stop", "⚠".bold().yellow());
             println!(
-                "{} 请手动停止服务器进程，然后删除锁文件:",
+                "{} Please stop the server process manually then delete the lock file:",
                 "ℹ".bold().blue()
             );
             println!("  {}", format!("del {}", lock_file).cyan());
             println!(
-                "{} 或使用任务管理器终止 shortlinker.exe 进程",
+                "{} Or terminate shortlinker.exe via Task Manager",
                 "ℹ".bold().blue()
             );
         }
@@ -182,7 +182,7 @@ impl ProcessManager {
     }
 
     pub fn restart_server() -> Result<(), CliError> {
-        println!("{} 正在重启 shortlinker 服务器...", "ℹ".bold().blue());
+        println!("{} Restarting shortlinker server...", "ℹ".bold().blue());
 
         #[cfg(unix)]
         {
@@ -197,9 +197,9 @@ impl ProcessManager {
             // 等待一小段时间确保端口释放
             std::thread::sleep(std::time::Duration::from_millis(1000));
 
-            println!("{} 启动新的服务器进程...", "ℹ".bold().blue());
+            println!("{} Starting new server process...", "ℹ".bold().blue());
             println!("  {}", "./shortlinker".cyan());
-            println!("{} 或在后台运行:", "ℹ".bold().blue());
+            println!("{} Or run in the background:", "ℹ".bold().blue());
             println!(
                 "  {}",
                 "nohup ./shortlinker > shortlinker.log 2>&1 &".cyan()
@@ -213,19 +213,19 @@ impl ProcessManager {
             let lock_file = ".shortlinker.lock";
 
             if Path::new(lock_file).exists() {
-                println!("{} 检测到锁文件，服务器可能正在运行", "⚠".bold().yellow());
-                println!("{} Windows 平台需要手动重启服务器:", "ℹ".bold().blue());
+                println!("{} Lock file detected, server might be running", "⚠".bold().yellow());
+                println!("{} Windows requires manual restart:", "ℹ".bold().blue());
                 println!();
                 println!(
-                    "{} 1. 使用任务管理器终止 shortlinker.exe 进程",
+                    "{} 1. Terminate shortlinker.exe via Task Manager",
                     "ℹ".bold().blue()
                 );
-                println!("{} 2. 删除锁文件:", "ℹ".bold().blue());
+                println!("{} 2. Delete the lock file:", "ℹ".bold().blue());
                 println!("   {}", format!("del {}", lock_file).cyan());
-                println!("{} 3. 重新启动服务器:", "ℹ".bold().blue());
+                println!("{} 3. Restart the server:", "ℹ".bold().blue());
                 println!("   {}", "shortlinker.exe".cyan());
             } else {
-                println!("{} 未发现运行中的服务器，直接启动:", "ℹ".bold().blue());
+                println!("{} No running server found, starting directly:", "ℹ".bold().blue());
                 println!("  {}", "shortlinker.exe".cyan());
             }
         }

--- a/src/middleware/auth.rs
+++ b/src/middleware/auth.rs
@@ -34,13 +34,13 @@ impl AuthMiddleware {
         if let Some(auth_header) = req.headers().get("Authorization") {
             if let Some(auth_bytes) = auth_header.as_bytes().strip_prefix(b"Bearer ") {
                 if auth_bytes == admin_token.as_bytes() {
-                    debug!("Admin API 鉴权成功");
+                    debug!("Admin API authentication succeeded");
                     return next.call(req).await;
                 }
             }
         }
 
-        info!("Admin API 鉴权失败: token不匹配或缺少Authorization header");
+        info!("Admin API authentication failed: token mismatch or missing Authorization header");
         Ok(req.into_response(
             HttpResponse::Unauthorized()
                 .append_header(("Content-Type", "application/json; charset=utf-8"))

--- a/src/middleware/health.rs
+++ b/src/middleware/health.rs
@@ -36,13 +36,13 @@ impl HealthMiddleware {
         if let Some(auth_header) = req.headers().get("Authorization") {
             if let Some(auth_bytes) = auth_header.as_bytes().strip_prefix(b"Bearer ") {
                 if auth_bytes == health_token.as_bytes() {
-                    debug!("Health API 鉴权成功");
+                    debug!("Health API authentication succeeded");
                     return next.call(req).await;
                 }
             }
         }
 
-        info!("Health API 鉴权失败: token不匹配或缺少Authorization header");
+        info!("Health API authentication failed: token mismatch or missing Authorization header");
         Ok(req.into_response(
             HttpResponse::Unauthorized()
                 .append_header(("Content-Type", "application/json; charset=utf-8"))

--- a/src/services/redirect.rs
+++ b/src/services/redirect.rs
@@ -17,7 +17,7 @@ impl RedirectService {
     ) -> impl Responder {
         let captured_path = path.into_inner();
 
-        debug!("捕获的路径: {}", captured_path);
+        debug!("Captured path: {}", captured_path);
 
         if captured_path.is_empty() {
             let default_url = DEFAULT_URL
@@ -49,7 +49,7 @@ impl RedirectService {
                     let _ = storage_clone.increment_click(&code_clone).await;
                 });
 
-                debug!("重定向 {} -> {}", captured_path, link.target);
+                debug!("Redirecting {} -> {}", captured_path, link.target);
 
                 HttpResponse::TemporaryRedirect()
                     .insert_header(("Location", link.target))
@@ -57,7 +57,7 @@ impl RedirectService {
                     .finish()
             }
             None => {
-                debug!("未找到重定向链接: {}", captured_path);
+                debug!("Redirect link not found: {}", captured_path);
                 HttpResponse::NotFound()
                     .insert_header(("Content-Type", "text/html; charset=utf-8"))
                     .insert_header(("Cache-Control", "public, max-age=60")) // 缓存404

--- a/src/storages/file.rs
+++ b/src/storages/file.rs
@@ -23,13 +23,13 @@ impl FileStorage {
             cache: DashMap::new(),
         };
 
-        // 初始化时加载数据到缓存
+        // Load data into cache during initialization
         let links = storage.load_from_file()?;
         for (code, link) in links {
             storage.cache.insert(code, link);
         }
         info!(
-            "FileStorage 初始化完成，已加载 {} 个短链接",
+            "FileStorage initialized with {} short links",
             storage.cache.len()
         );
 
@@ -62,27 +62,27 @@ impl FileStorage {
                             },
                         );
                     }
-                    info!("已加载 {} 个短链接", map.len());
+                    info!("Loaded {} short links", map.len());
                     Ok(map)
                 }
                 Err(e) => {
-                    error!("解析链接文件失败: {}", e);
+                    error!("Failed to parse link file: {}", e);
                     Err(ShortlinkerError::serialization(format!(
-                        "解析链接文件失败: {}",
+                        "Failed to parse link file: {}",
                         e
                     )))
                 }
             },
             Err(_) => {
-                info!("链接文件不存在，创建空的存储");
+                info!("Link file not found, creating empty storage");
                 if let Err(e) = fs::write(&self.file_path, "[]") {
-                    error!("创建链接文件失败: {}", e);
+                    error!("Failed to create link file: {}", e);
                     return Err(ShortlinkerError::file_operation(format!(
-                        "创建链接文件失败: {}",
+                        "Failed to create link file: {}",
                         e
                     )));
                 }
-                info!("已创建空的链接文件: {}", self.file_path);
+                info!("Created empty link file: {}", self.file_path);
                 Ok(HashMap::new())
             }
         }
@@ -175,11 +175,11 @@ impl Storage for FileStorage {
                 for (code, link) in new_links {
                     self.cache.insert(code, link);
                 }
-                info!("缓存重载完成");
+                info!("Cache reloaded");
                 Ok(())
             }
             Err(e) => {
-                error!("重载失败: {}", e);
+                error!("Reload failed: {}", e);
                 Err(e)
             }
         }

--- a/src/storages/sqlite.rs
+++ b/src/storages/sqlite.rs
@@ -62,10 +62,10 @@ impl SqliteStorage {
 
         let storage = SqliteStorage { pool, cache };
 
-        // 初始化数据库表
+        // Initialize database tables
         storage.init_db()?;
 
-        warn!("SqliteStorage 初始化完成，数据库路径: {}", db_path);
+        warn!("SqliteStorage initialized, database path: {}", db_path);
         Ok(storage)
     }
 
@@ -141,11 +141,11 @@ impl Storage for SqliteStorage {
             return Some(link);
         }
 
-        // 缓存未命中，从数据库查询
+        // Cache miss, query database
         let conn = match self.get_connection() {
             Ok(conn) => conn,
             Err(e) => {
-                error!("获取数据库连接失败: {}", e);
+                error!("Failed to get database connection: {}", e);
                 return None;
             }
         };
@@ -177,23 +177,23 @@ impl Storage for SqliteStorage {
                     expires_at,
                 ) {
                     Ok(link) => {
-                        // 将查询结果放入缓存
+                        // Store result into cache
                         cache.insert(short_code, link.clone()).await;
                         Some(link)
                     }
                     Err(e) => {
-                        error!("解析短链接数据失败: {}", e);
+                        error!("Failed to parse short link data: {}", e);
                         None
                     }
                 }
             }
             Ok(Err(rusqlite::Error::QueryReturnedNoRows)) => None,
             Ok(Err(e)) => {
-                error!("查询短链接失败: {}", e);
+                error!("Query short link failed: {}", e);
                 None
             }
             Err(e) => {
-                error!("执行异步查询失败: {:?}", e);
+                error!("Async query failed: {:?}", e);
                 None
             }
         }
@@ -203,7 +203,7 @@ impl Storage for SqliteStorage {
         let conn = match self.get_connection() {
             Ok(conn) => conn,
             Err(e) => {
-                error!("获取数据库连接失败: {}", e);
+                error!("Failed to get database connection: {}", e);
                 return HashMap::new();
             }
         };
@@ -215,7 +215,7 @@ impl Storage for SqliteStorage {
         {
             Ok(stmt) => stmt,
             Err(e) => {
-                error!("准备查询语句失败: {}", e);
+                error!("Failed to prepare query statement: {}", e);
                 return links;
             }
         };
@@ -230,7 +230,7 @@ impl Storage for SqliteStorage {
         }) {
             Ok(rows) => rows,
             Err(e) => {
-                error!("查询所有短链接失败: {}", e);
+                error!("Failed to query all short links: {}", e);
                 return links;
             }
         };
@@ -248,17 +248,17 @@ impl Storage for SqliteStorage {
                             links.insert(short_code, link);
                         }
                         Err(e) => {
-                            error!("解析短链接数据失败: {}", e);
+                            error!("Failed to parse short link data: {}", e);
                         }
                     }
                 }
                 Err(e) => {
-                    error!("读取行数据失败: {}", e);
+                    error!("Failed to read row data: {}", e);
                 }
             }
         }
 
-        info!("已加载 {} 个短链接", links.len());
+        info!("Loaded {} short links", links.len());
         links
     }
 
@@ -304,7 +304,7 @@ impl Storage for SqliteStorage {
                         ShortlinkerError::database_operation(format!("更新短链接失败: {}", e))
                     })
                     .map(|_| {
-                        info!("短链接已更新: {}", link_clone.code);
+                        info!("Short link updated: {}", link_clone.code);
                     })
             } else {
                 transaction
@@ -317,7 +317,7 @@ impl Storage for SqliteStorage {
                         ShortlinkerError::database_operation(format!("插入短链接失败: {}", e))
                     })
                     .map(|_| {
-                        info!("短链接已创建: {}", link_clone.code);
+                        info!("Short link created: {}", link_clone.code);
                     })
             };
 
@@ -389,7 +389,7 @@ impl Storage for SqliteStorage {
                 ShortlinkerError::database_operation(format!("提交事务失败: {}", e))
             })?;
 
-            info!("短链接已删除: {}", code);
+            info!("Short link deleted: {}", code);
             Ok(code)
         })
         .await;
@@ -409,9 +409,9 @@ impl Storage for SqliteStorage {
     }
 
     async fn reload(&self) -> Result<()> {
-        // 清空缓存，强制重新从数据库加载
+        // Clear cache to force reload from database
         self.cache.invalidate_all();
-        info!("SQLite 缓存已清空，数据将从数据库重新加载");
+        info!("SQLite cache cleared, data will be reloaded from database");
         Ok(())
     }
 

--- a/src/system/lockfile.rs
+++ b/src/system/lockfile.rs
@@ -21,16 +21,16 @@ pub fn init_lockfile() -> Result<(), std::io::Error> {
 
                     // 如果当前进程是 PID 1 且旧 PID 也是 1，说明是容器重启
                     if current_pid == 1 && old_pid == 1 {
-                        info!("检测到容器重启，清理旧的 PID 文件");
+                        info!("Container restart detected, removing old PID file");
                         let _ = fs::remove_file(pid_file);
                     } else if signal::kill(Pid::from_raw(old_pid as i32), None).is_ok() {
-                        error!("服务器已在运行 (PID: {})，请先停止现有进程", old_pid);
-                        error!("可以使用以下命令停止:");
+                        error!("Server already running (PID: {}), stop it first", old_pid);
+                        error!("You can stop it with:");
                         error!("  kill {}", old_pid);
                         std::process::exit(1);
                     } else {
                         // 进程已停止，清理旧的 PID 文件
-                        info!("检测到孤立的 PID 文件，清理中...");
+                        info!("Stale PID file detected, cleaning up...");
                         let _ = fs::remove_file(pid_file);
                     }
                 }
@@ -45,10 +45,10 @@ pub fn init_lockfile() -> Result<(), std::io::Error> {
     // 写入当前进程的 PID
     let pid = process::id();
     if let Err(e) = fs::write(pid_file, pid.to_string()) {
-        error!("无法写入PID文件: {}", e);
+        error!("Failed to write PID file: {}", e);
         return Err(e);
     } else {
-        info!("服务器 PID: {}", pid);
+        info!("Server PID: {}", pid);
     }
 
     Ok(())
@@ -61,10 +61,10 @@ pub fn init_lockfile() -> Result<(), std::io::Error> {
     use std::path::Path;
 
     let lock_file = ".shortlinker.lock";
-    // 检查是否已有锁文件存在
+    // Check if lock file already exists
     if Path::new(lock_file).exists() {
-        error!("服务器已在运行，请先停止现有进程");
-        error!("如果确认服务器没有运行，可以删除锁文件: {}", lock_file);
+        error!("Server already running, stop it first");
+        error!("If the server is not running, delete the lock file: {}", lock_file);
         return Err(io::Error::new(
             io::ErrorKind::AlreadyExists,
             "Server is already running",
@@ -74,12 +74,12 @@ pub fn init_lockfile() -> Result<(), std::io::Error> {
     match fs::File::create(lock_file) {
         Ok(mut file) => {
             if let Err(e) = writeln!(file, "Server is running") {
-                error!("无法写入锁文件: {}", e);
+                error!("Failed to write lock file: {}", e);
                 return Err(e);
             }
         }
         Err(e) => {
-            error!("无法创建锁文件: {}", e);
+            error!("Failed to create lock file: {}", e);
             return Err(e);
         }
     }
@@ -92,9 +92,9 @@ pub fn init_lockfile() -> Result<(), std::io::Error> {
 pub fn cleanup_lockfile() {
     let pid_file = "shortlinker.pid";
     if let Err(e) = fs::remove_file(pid_file) {
-        error!("无法删除PID文件: {}", e);
+        error!("Failed to delete PID file: {}", e);
     } else {
-        info!("已清理PID文件: {}", pid_file);
+        info!("PID file cleaned: {}", pid_file);
     }
 }
 
@@ -102,8 +102,8 @@ pub fn cleanup_lockfile() {
 pub fn cleanup_lockfile() {
     let lock_file = ".shortlinker.lock";
     if let Err(e) = fs::remove_file(lock_file) {
-        error!("无法删除锁文件: {}", e);
+        error!("Failed to delete lock file: {}", e);
     } else {
-        info!("已清理锁文件: {}", lock_file);
+        info!("Lock file cleaned: {}", lock_file);
     }
 }

--- a/src/system/reload.rs
+++ b/src/system/reload.rs
@@ -10,12 +10,12 @@ pub fn setup_reload_mechanism(storage: Arc<dyn storages::Storage>) {
     thread::spawn(move || {
         let mut signals = Signals::new([SIGUSR1]).unwrap();
         for _ in signals.forever() {
-            tracing::info!("收到 SIGUSR1，正在从 Storage 重载链接");
+            tracing::info!("Received SIGUSR1, reloading links from storage");
             if let Err(e) = futures::executor::block_on(storage.reload()) {
-                tracing::error!("重载链接配置失败: {}", e);
+                tracing::error!("Failed to reload link configuration: {}", e);
                 continue;
             }
-            tracing::info!("链接配置已重载");
+            tracing::info!("Link configuration reloaded");
         }
     });
 }
@@ -36,14 +36,14 @@ pub fn setup_reload_mechanism(storage: Arc<dyn storages::Storage>) {
             if let Ok(metadata) = fs::metadata(reload_file) {
                 if let Ok(modified) = metadata.modified() {
                     if modified > last_check {
-                        tracing::info!("检测到重新加载请求，正在从 Storage 重载链接");
+                        tracing::info!("Reload request detected, reloading links from storage");
                         if let Err(e) = futures::executor::block_on(storage.reload()) {
-                            tracing::error!("重载链接配置失败: {}", e);
+                            tracing::error!("Failed to reload link configuration: {}", e);
                             last_check = SystemTime::now();
                             continue;
                         }
                         last_check = SystemTime::now();
-                        tracing::info!("链接配置已重载");
+                        tracing::info!("Link configuration reloaded");
 
                         // 删除触发文件
                         let _ = fs::remove_file(reload_file);

--- a/src/system/signal.rs
+++ b/src/system/signal.rs
@@ -12,14 +12,14 @@ pub fn notify_server() -> Result<()> {
             let pid: i32 = pid_str
                 .trim()
                 .parse()
-                .map_err(|e| ShortlinkerError::validation(format!("PID格式无效: {}", e)))?;
+                .map_err(|e| ShortlinkerError::validation(format!("Invalid PID format: {}", e)))?;
             signal::kill(Pid::from_raw(pid), Signal::SIGUSR1)
-                .map_err(|e| ShortlinkerError::signal_operation(format!("发送信号失败: {}", e)))?;
-            println!("已通知服务器重新加载配置");
+                .map_err(|e| ShortlinkerError::signal_operation(format!("Failed to send signal: {}", e)))?;
+            println!("Server reload notified");
             Ok(())
         }
         Err(_) => {
-            println!("警告: 无法找到服务器进程，请手动重启服务器");
+            println!("Warning: server process not found, please restart manually");
             Ok(())
         }
     }
@@ -27,16 +27,16 @@ pub fn notify_server() -> Result<()> {
 
 #[cfg(windows)]
 pub fn notify_server() -> Result<()> {
-    // Windows平台使用触发文件方式
+    // On Windows use a trigger file
     match fs::write("shortlinker.reload", "") {
         Ok(_) => {
-            println!("已通知服务器重新加载配置");
+            println!("Server reload notified");
             Ok(())
         }
         Err(e) => {
-            println!("通知服务器失败: {}", e);
+            println!("Failed to notify server: {}", e);
             Err(ShortlinkerError::file_operation(format!(
-                "通知服务器失败: {}",
+                "Failed to notify server: {}",
                 e
             )))
         }


### PR DESCRIPTION
## Summary
- convert CLI logs from Chinese to English
- translate admin, middleware and service logs
- update storage-related log messages
- revise system module logs

## Testing
- `cargo test --quiet` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_b_68418065d6d88320b4964a2b5bb62ab2