### PR TITLE
Document CLI server management

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -62,6 +62,30 @@
 ./shortlinker list
 ```
 
+### start - 后台启动服务器
+
+```bash
+./shortlinker start
+```
+
+### stop - 停止服务器
+
+```bash
+./shortlinker stop
+```
+
+### restart - 重启服务器
+
+```bash
+./shortlinker restart
+```
+
+### help - 查看帮助
+
+```bash
+./shortlinker help
+```
+
 ### update - 更新短链接
 
 ```bash

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -20,6 +20,10 @@ Shortlinker 提供了直观易用的命令行工具，用于管理短链接。
 
 | 命令 | 功能 | 示例 |
 |------|------|------|
+| `help` | 查看帮助 | `./shortlinker help` |
+| `start` | 启动服务器 | `./shortlinker start` |
+| `stop` | 停止服务器 | `./shortlinker stop` |
+| `restart` | 重启服务器 | `./shortlinker restart` |
 | `add` | 添加短链接 | `./shortlinker add github https://github.com` |
 | `remove` | 删除短链接 | `./shortlinker remove github` |
 | `update` | 更新短链接 | `./shortlinker update github https://new-url.com` |

--- a/docs/en/cli/commands.md
+++ b/docs/en/cli/commands.md
@@ -79,6 +79,30 @@ Detailed command line tool usage instructions and parameter options.
 ./shortlinker list
 ```
 
+### start - Start server in background
+
+```bash
+./shortlinker start
+```
+
+### stop - Stop running server
+
+```bash
+./shortlinker stop
+```
+
+### restart - Restart server
+
+```bash
+./shortlinker restart
+```
+
+### help - Show command help
+
+```bash
+./shortlinker help
+```
+
 **Output Format**:
 ```bash
 Short links list:

--- a/docs/en/cli/index.md
+++ b/docs/en/cli/index.md
@@ -20,6 +20,10 @@ Shortlinker provides an intuitive and easy-to-use command line tool for managing
 
 | Command | Function | Example |
 |---------|----------|---------|
+| `help` | Show help | `./shortlinker help` |
+| `start` | Start server | `./shortlinker start` |
+| `stop` | Stop server | `./shortlinker stop` |
+| `restart` | Restart server | `./shortlinker restart` |
 | `add` | Add short link | `./shortlinker add github https://github.com` |
 | `remove` | Delete short link | `./shortlinker remove github` |
 | `update` | Update short link | `./shortlinker update github https://new-url.com` |


### PR DESCRIPTION
## Summary
- document `help`, `start`, `stop` and `restart` commands for the CLI
- add command references to the CLI quick overview tables

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_b_6841835900188320a54240e77338b2b4