### PR TITLE
Centralize struct definitions

### DIFF
--- a/src/cli/commands/link_management.rs
+++ b/src/cli/commands/link_management.rs
@@ -1,5 +1,5 @@
 use super::super::CliError;
-use crate::storages::{SerializableShortLink, ShortLink, Storage};
+use crate::storages::{StorageSerializableShortLink, ShortLink, Storage};
 use crate::utils::generate_random_code;
 use crate::utils::TimeParser;
 use colored::*;
@@ -276,9 +276,9 @@ pub async fn export_links(
     }
 
     // 转换为可序列化格式
-    let serializable_links: Vec<SerializableShortLink> = links
+    let serializable_links: Vec<StorageSerializableShortLink> = links
         .values()
-        .map(|link| SerializableShortLink {
+        .map(|link| StorageSerializableShortLink {
             short_code: link.code.clone(),
             target_url: link.target.clone(),
             created_at: link.created_at.to_rfc3339(),
@@ -333,7 +333,7 @@ pub async fn import_links(
     })?;
 
     let reader = BufReader::new(file);
-    let serializable_links: Vec<SerializableShortLink> = serde_json::from_reader(reader)
+    let serializable_links: Vec<StorageSerializableShortLink> = serde_json::from_reader(reader)
         .map_err(|e| CliError::CommandError(format!("Failed to parse JSON file: {}", e)))?;
 
     if serializable_links.is_empty() {

--- a/src/cli/parser.rs
+++ b/src/cli/parser.rs
@@ -1,7 +1,6 @@
 use super::{commands::Command, CliError};
 use std::env;
-
-pub struct CliParser;
+pub use crate::structs::CliParser;
 
 impl Default for CliParser {
     fn default() -> Self {

--- a/src/cli/process_manager.rs
+++ b/src/cli/process_manager.rs
@@ -1,7 +1,6 @@
 use super::CliError;
 use colored::*;
-
-pub struct ProcessManager;
+pub use crate::structs::ProcessManager;
 
 impl ProcessManager {
     pub fn start_server() -> Result<(), CliError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod services;
 pub mod storages;
 pub mod system;
 pub mod utils;
+pub mod structs;
 
 #[cfg(test)]
 mod tests {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,20 +13,14 @@ mod services;
 mod storages;
 mod system;
 mod utils;
+mod structs;
 
 use crate::middleware::{AdminAuth, HealthAuth};
 use crate::services::{AdminService, AppStartTime, HealthService, RedirectService};
 use crate::storages::StorageFactory;
 use crate::system::{cleanup_lockfile, init_lockfile};
+use crate::structs::Config;
 
-// 配置结构体
-#[derive(Clone, Debug)]
-struct Config {
-    server_host: String,
-    server_port: u16,
-    #[cfg(unix)]
-    unix_socket_path: Option<String>,
-}
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {

--- a/src/services/admin.rs
+++ b/src/services/admin.rs
@@ -8,56 +8,15 @@ use tracing::{debug, error, info};
 
 use crate::storages::{ShortLink, Storage};
 use crate::utils::{generate_random_code, TimeParser};
+use crate::structs::{
+    ApiResponse, GetLinksQuery, PaginationInfo, PaginatedResponse, PostNewLink,
+    SerializableShortLink,
+};
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct SerializableShortLink {
-    pub short_code: String,
-    pub target_url: String,
-    pub created_at: String,
-    pub expires_at: Option<String>,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct ApiResponse<T> {
-    pub code: i32,
-    pub data: T,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct PostNewLink {
-    pub code: Option<String>,
-    pub target: String,
-    pub expires_at: Option<String>,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct GetLinksQuery {
-    pub page: Option<usize>,
-    pub page_size: Option<usize>,
-    pub created_after: Option<String>,
-    pub created_before: Option<String>,
-    pub only_expired: Option<bool>,
-    pub only_active: Option<bool>,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct PaginatedResponse<T> {
-    pub code: i32,
-    pub data: T,
-    pub pagination: PaginationInfo,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct PaginationInfo {
-    pub page: usize,
-    pub page_size: usize,
-    pub total: usize,
-    pub total_pages: usize,
-}
 
 static RANDOM_CODE_LENGTH: OnceLock<usize> = OnceLock::new();
 
-pub struct AdminService;
+pub use crate::structs::AdminService;
 
 impl AdminService {
     pub async fn get_all_links(

--- a/src/services/health.rs
+++ b/src/services/health.rs
@@ -6,12 +6,7 @@ use tracing::{debug, error, info};
 
 use crate::storages::Storage;
 use crate::utils::TimeParser;
-
-// 应用启动时间结构体
-#[derive(Clone, Debug)]
-pub struct AppStartTime {
-    pub start_datetime: chrono::DateTime<chrono::Utc>,
-}
+use crate::structs::AppStartTime;
 
 pub struct HealthService;
 

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -4,6 +4,4 @@ pub mod redirect;
 
 pub use admin::AdminService;
 pub use health::HealthService;
-pub use redirect::RedirectService;
-
-pub use health::AppStartTime;
+pub use crate::structs::{AppStartTime, RedirectService};

--- a/src/services/redirect.rs
+++ b/src/services/redirect.rs
@@ -5,10 +5,9 @@ use std::sync::OnceLock;
 use tracing::debug;
 
 use crate::storages::Storage;
+pub use crate::structs::RedirectService;
 
 static DEFAULT_URL: OnceLock<String> = OnceLock::new();
-
-pub struct RedirectService {}
 
 impl RedirectService {
     pub async fn handle_redirect(

--- a/src/storages/file.rs
+++ b/src/storages/file.rs
@@ -8,7 +8,7 @@ use super::{ShortLink, Storage};
 use async_trait::async_trait;
 
 use crate::errors::{Result, ShortlinkerError};
-use crate::storages::SerializableShortLink;
+use crate::storages::StorageSerializableShortLink;
 
 pub struct FileStorage {
     file_path: String,
@@ -38,7 +38,7 @@ impl FileStorage {
 
     fn load_from_file(&self) -> Result<HashMap<String, ShortLink>> {
         match fs::read_to_string(&self.file_path) {
-            Ok(content) => match serde_json::from_str::<Vec<SerializableShortLink>>(&content) {
+            Ok(content) => match serde_json::from_str::<Vec<StorageSerializableShortLink>>(&content) {
                 Ok(links) => {
                     let mut map = HashMap::new();
                     for link in links {
@@ -89,9 +89,9 @@ impl FileStorage {
     }
 
     fn save_to_file(&self, links: &HashMap<String, ShortLink>) -> Result<()> {
-        let links_vec: Vec<SerializableShortLink> = links
+        let links_vec: Vec<StorageSerializableShortLink> = links
             .iter()
-            .map(|(_, link)| SerializableShortLink {
+            .map(|(_, link)| StorageSerializableShortLink {
                 short_code: link.code.clone(),
                 target_url: link.target.clone(),
                 created_at: link.created_at.to_rfc3339(),

--- a/src/storages/mod.rs
+++ b/src/storages/mod.rs
@@ -3,28 +3,11 @@ use std::env;
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
+pub use crate::structs::{ShortLink, StorageSerializableShortLink};
 
 use crate::errors::Result;
 use async_trait::async_trait;
 
-#[derive(Debug, Clone)]
-pub struct ShortLink {
-    pub code: String,
-    pub target: String,
-    pub created_at: chrono::DateTime<chrono::Utc>,
-    pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct SerializableShortLink {
-    pub short_code: String,
-    pub target_url: String,
-    pub created_at: String,
-    pub expires_at: Option<String>,
-
-    #[serde(default)]
-    pub click: usize,
-}
 
 #[async_trait]
 pub trait Storage: Send + Sync {

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,0 +1,94 @@
+pub use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug)]
+pub struct Config {
+    pub server_host: String,
+    pub server_port: u16,
+    #[cfg(unix)]
+    pub unix_socket_path: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ShortLink {
+    pub code: String,
+    pub target: String,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct StorageSerializableShortLink {
+    pub short_code: String,
+    pub target_url: String,
+    pub created_at: String,
+    pub expires_at: Option<String>,
+
+    #[serde(default)]
+    pub click: usize,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct SerializableShortLink {
+    pub short_code: String,
+    pub target_url: String,
+    pub created_at: String,
+    pub expires_at: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct ApiResponse<T> {
+    pub code: i32,
+    pub data: T,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct PostNewLink {
+    pub code: Option<String>,
+    pub target: String,
+    pub expires_at: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct GetLinksQuery {
+    pub page: Option<usize>,
+    pub page_size: Option<usize>,
+    pub created_after: Option<String>,
+    pub created_before: Option<String>,
+    pub only_expired: Option<bool>,
+    pub only_active: Option<bool>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct PaginatedResponse<T> {
+    pub code: i32,
+    pub data: T,
+    pub pagination: PaginationInfo,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct PaginationInfo {
+    pub page: usize,
+    pub page_size: usize,
+    pub total: usize,
+    pub total_pages: usize,
+}
+
+#[derive(Clone, Debug)]
+pub struct AppStartTime {
+    pub start_datetime: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TimeParser;
+
+#[derive(Debug, Clone)]
+pub struct CliParser;
+
+#[derive(Debug, Clone)]
+pub struct ProcessManager;
+
+#[derive(Debug, Clone)]
+pub struct AdminService;
+
+#[derive(Debug, Clone)]
+pub struct RedirectService;

--- a/src/utils/time_parser.rs
+++ b/src/utils/time_parser.rs
@@ -1,7 +1,6 @@
 use chrono::{DateTime, Duration, Utc};
+pub use crate::structs::TimeParser;
 
-#[derive(Debug, Clone)]
-pub struct TimeParser;
 
 impl TimeParser {
     /// 解析时间字符串，支持多种格式：


### PR DESCRIPTION
## Summary
- create `structs.rs` to hold common data structures
- import types from new module across the app
- rename storage-specific `SerializableShortLink`

## Testing
- `cargo check`
- `cargo test --quiet` *(fails: could not find `colors` module and other test issues)*

------
https://chatgpt.com/codex/tasks/task_b_684285f91274832097208b4caf3644e8