### PR TITLE
Add Rust and Vue unit tests

### DIFF
--- a/admin-panel/src/__tests__/authStore.spec.ts
+++ b/admin-panel/src/__tests__/authStore.spec.ts
@@ -1,0 +1,27 @@
+import { setActivePinia, createPinia } from 'pinia'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useAuthStore } from '@/stores/auth'
+
+describe('useAuthStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+  })
+
+  it('login stores token', () => {
+    const store = useAuthStore()
+    store.login('secret')
+    expect(store.token).toBe('secret')
+    expect(localStorage.getItem('adminToken')).toBe('secret')
+    expect(store.isAuthenticated).toBe(true)
+  })
+
+  it('logout clears token', () => {
+    const store = useAuthStore()
+    store.login('secret')
+    store.logout()
+    expect(store.token).toBeNull()
+    expect(localStorage.getItem('adminToken')).toBeNull()
+    expect(store.isAuthenticated).toBe(false)
+  })
+})

--- a/admin-panel/src/__tests__/linkService.spec.ts
+++ b/admin-panel/src/__tests__/linkService.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { LinkService } from '@/services/linkService'
+import type { SerializableShortLink, LinkPayload } from '@/services/types'
+
+describe('LinkService.createWithCheck', () => {
+  let service: LinkService
+
+  beforeEach(() => {
+    service = new LinkService()
+  })
+
+  it('returns existing link when duplicate', async () => {
+    const payload: LinkPayload = { code: 'abc', target: 'https://a.com' }
+    const existing: SerializableShortLink = {
+      short_code: 'abc',
+      target_url: 'https://a.com',
+      created_at: '',
+      expires_at: null
+    }
+    service.fetchOne = vi.fn().mockResolvedValue(existing)
+    service.create = vi.fn()
+
+    const result = await service.createWithCheck(payload)
+    expect(result).toEqual({ success: false, exists: true, existingLink: existing })
+    expect(service.create).not.toHaveBeenCalled()
+  })
+
+  it('creates new link when none exists', async () => {
+    const payload: LinkPayload = { code: 'abc', target: 'https://a.com' }
+    service.fetchOne = vi.fn().mockResolvedValue(null)
+    service.create = vi.fn().mockResolvedValue(undefined)
+
+    const result = await service.createWithCheck(payload)
+    expect(service.create).toHaveBeenCalledWith(payload)
+    expect(result).toEqual({ success: true })
+  })
+
+  it('skips check when force is true', async () => {
+    const payload: LinkPayload = { code: 'abc', target: 'https://a.com', force: true }
+    const fetchSpy = vi.spyOn(service, 'fetchOne')
+    service.create = vi.fn().mockResolvedValue(undefined)
+
+    const result = await service.createWithCheck(payload)
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(service.create).toHaveBeenCalledWith(payload)
+    expect(result).toEqual({ success: true })
+  })
+})

--- a/tests/errors_tests.rs
+++ b/tests/errors_tests.rs
@@ -106,9 +106,8 @@ mod error_conversion_tests {
         let parse_error = chrono::DateTime::parse_from_rfc3339(invalid_date).unwrap_err();
         let shortlinker_error: ShortlinkerError = parse_error.into();
 
-        assert!(matches!(shortlinker_error, ShortlinkerError::Validation(_)));
-        assert!(shortlinker_error.to_string().contains("验证错误"));
-        assert!(shortlinker_error.to_string().contains("时间解析错误"));
+        assert!(matches!(shortlinker_error, ShortlinkerError::DateParse(_)));
+        assert!(shortlinker_error.to_string().contains("日期解析错误"));
     }
 }
 

--- a/tests/middleware_tests.rs
+++ b/tests/middleware_tests.rs
@@ -1,0 +1,86 @@
+use actix_web::{test, web, App, HttpResponse, http::StatusCode, http::Method};
+use shortlinker::middleware::AdminAuth;
+use std::sync::Mutex;
+
+static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+#[actix_web::test]
+async fn admin_auth_missing_token_returns_404() {
+    let _guard = ENV_MUTEX.lock().unwrap();
+    std::env::set_var("ADMIN_TOKEN", "");
+    std::env::set_var("ADMIN_ROUTE_PREFIX", "/admin");
+
+    let app = test::init_service(
+        App::new()
+            .wrap(AdminAuth)
+            .route("/admin/test", web::get().to(|| async { HttpResponse::Ok() }))
+    ).await;
+
+    let req = test::TestRequest::get().uri("/admin/test").to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[actix_web::test]
+async fn admin_auth_allows_login_without_token() {
+    let _guard = ENV_MUTEX.lock().unwrap();
+    std::env::set_var("ADMIN_TOKEN", "secret");
+    std::env::set_var("ADMIN_ROUTE_PREFIX", "/admin");
+
+    let app = test::init_service(
+        App::new()
+            .wrap(AdminAuth)
+            .route("/admin/auth/login", web::get().to(|| async { HttpResponse::Ok() }))
+    ).await;
+
+    let req = test::TestRequest::get().uri("/admin/auth/login").to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[actix_web::test]
+async fn admin_auth_validates_token() {
+    let _guard = ENV_MUTEX.lock().unwrap();
+    std::env::set_var("ADMIN_TOKEN", "secret");
+    std::env::set_var("ADMIN_ROUTE_PREFIX", "/admin");
+
+    let app = test::init_service(
+        App::new()
+            .wrap(AdminAuth)
+            .route("/admin/protected", web::get().to(|| async { HttpResponse::Ok() }))
+    ).await;
+
+    let req = test::TestRequest::get()
+        .uri("/admin/protected")
+        .insert_header(("Authorization", "Bearer secret"))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let req_invalid = test::TestRequest::get()
+        .uri("/admin/protected")
+        .insert_header(("Authorization", "Bearer wrong"))
+        .to_request();
+    let resp = test::call_service(&app, req_invalid).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[actix_web::test]
+async fn admin_auth_handles_options() {
+    let _guard = ENV_MUTEX.lock().unwrap();
+    std::env::set_var("ADMIN_TOKEN", "secret");
+    std::env::set_var("ADMIN_ROUTE_PREFIX", "/admin");
+
+    let app = test::init_service(
+        App::new()
+            .wrap(AdminAuth)
+            .route("/admin/test", web::get().to(|| async { HttpResponse::Ok() }))
+    ).await;
+
+    let req = test::TestRequest::default()
+        .method(Method::OPTIONS)
+        .uri("/admin/test")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+}

--- a/tests/utils_new_tests.rs
+++ b/tests/utils_new_tests.rs
@@ -1,0 +1,24 @@
+use shortlinker::utils::generate_random_code;
+use std::collections::HashSet;
+
+#[test]
+fn generate_random_code_length() {
+    let code = generate_random_code(8);
+    assert_eq!(code.len(), 8);
+    assert!(code.chars().all(|c| c.is_ascii_alphanumeric()));
+}
+
+#[test]
+fn generate_random_code_zero() {
+    let code = generate_random_code(0);
+    assert!(code.is_empty());
+}
+
+#[test]
+fn generate_random_code_uniqueness() {
+    let mut codes = HashSet::new();
+    for _ in 0..100 {
+        codes.insert(generate_random_code(6));
+    }
+    assert!(codes.len() > 90);
+}


### PR DESCRIPTION
## Summary
- add middleware tests for admin authentication logic
- cover random code generation
- update error conversion expectation
- include vitest suites for Pinia auth store and link service

## Testing
- `cargo test --quiet`
- `yarn vitest run --silent`

------
https://chatgpt.com/codex/tasks/task_b_6844baa135b08320802ab5414895355c