### PR TITLE
Add Redis object cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "async-lock"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,6 +301,15 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "backon"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "302eaff5357a264a2c42f127ecb8bac761cf99749fc3dc95677e2743991f99e7"
+dependencies = [
+ "fastrand",
+]
 
 [[package]]
 name = "backtrace"
@@ -433,6 +448,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1300,10 +1329,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1526,6 +1574,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
+]
+
+[[package]]
+name = "redis"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd673deb3d184140109c1e27b043c2354cb79399c3ef304c365fc628092ed773"
+dependencies = [
+ "arc-swap",
+ "backon",
+ "bytes",
+ "cfg-if",
+ "combine",
+ "futures-channel",
+ "futures-util",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "url",
 ]
 
 [[package]]
@@ -1771,6 +1843,7 @@ dependencies = [
  "r2d2",
  "r2d2_sqlite",
  "rand",
+ "redis",
  "rusqlite",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ once_cell = "1.21.3"
 ctor = "0.4.2"
 tracing-attributes = "0.1.29"
 anyhow = "1.0.98"
+redis = { version = "0.32", default-features = false, features = ["tokio-comp", "connection-manager"] }
 
 [target.'cfg(unix)'.dependencies]
 signal-hook = { version = "0.3", default-features = false, features = ["iterator"] }

--- a/src/cache/object_cache/mod.rs
+++ b/src/cache/object_cache/mod.rs
@@ -1,3 +1,4 @@
 pub mod memory;
 pub mod moka;
 pub mod null;
+pub mod redis;

--- a/src/cache/object_cache/redis.rs
+++ b/src/cache/object_cache/redis.rs
@@ -1,0 +1,101 @@
+use crate::cache::traits::{CacheResult, ObjectCache};
+use crate::declare_object_cache_plugin;
+use crate::storages::{SerializableShortLink, ShortLink};
+use async_trait::async_trait;
+use redis::aio::ConnectionManager;
+use redis::AsyncCommands;
+use std::collections::HashMap;
+use std::env;
+
+/// Redis based object cache implementation
+///
+/// Requires `REDIS_URL` environment variable, defaulting to `redis://127.0.0.1/`
+declare_object_cache_plugin!("redis", RedisCache);
+
+pub struct RedisCache {
+    conn: ConnectionManager,
+}
+
+impl RedisCache {
+    pub fn new() -> Self {
+        let url = env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1/".to_string());
+        let client = redis::Client::open(url).expect("Failed to create Redis client");
+        // initialization happens in synchronous context, block on async connection
+        let conn = tokio::runtime::Handle::current()
+            .block_on(client.get_tokio_connection_manager())
+            .expect("Failed to create Redis connection manager");
+        Self { conn }
+    }
+
+    fn to_serializable(link: &ShortLink) -> SerializableShortLink {
+        SerializableShortLink {
+            short_code: link.code.clone(),
+            target_url: link.target.clone(),
+            created_at: link.created_at.to_rfc3339(),
+            expires_at: link.expires_at.map(|dt| dt.to_rfc3339()),
+            click: 0,
+        }
+    }
+
+    fn from_serializable(link: SerializableShortLink) -> ShortLink {
+        let created_at = chrono::DateTime::parse_from_rfc3339(&link.created_at)
+            .unwrap_or_else(|_| chrono::Utc::now().into())
+            .with_timezone(&chrono::Utc);
+        let expires_at = link
+            .expires_at
+            .and_then(|s| chrono::DateTime::parse_from_rfc3339(&s).ok())
+            .map(|dt| dt.with_timezone(&chrono::Utc));
+        ShortLink {
+            code: link.short_code,
+            target: link.target_url,
+            created_at,
+            expires_at,
+        }
+    }
+}
+
+#[async_trait]
+impl ObjectCache for RedisCache {
+    async fn get(&self, key: &str) -> CacheResult {
+        let mut conn = self.conn.clone();
+        match conn.get::<_, Option<String>>(key).await {
+            Ok(Some(data)) => match serde_json::from_str::<SerializableShortLink>(&data) {
+                Ok(s) => CacheResult::Found(Self::from_serializable(s)),
+                Err(_) => CacheResult::ExistsButNoValue,
+            },
+            Ok(None) => CacheResult::NotFound,
+            Err(e) => {
+                tracing::error!("Redis get error: {}", e);
+                CacheResult::NotFound
+            }
+        }
+    }
+
+    async fn insert(&self, key: String, value: ShortLink) {
+        let mut conn = self.conn.clone();
+        if let Ok(json) = serde_json::to_string(&Self::to_serializable(&value)) {
+            let _: redis::RedisResult<()> = conn.set(key, json).await;
+        }
+    }
+
+    async fn remove(&self, key: &str) {
+        let mut conn = self.conn.clone();
+        let _: redis::RedisResult<()> = conn.del(key).await;
+    }
+
+    async fn invalidate_all(&self) {
+        let mut conn = self.conn.clone();
+        let _: redis::RedisResult<()> = redis::cmd("FLUSHDB").query_async(&mut conn).await;
+    }
+
+    async fn load_l2_cache(&self, keys: HashMap<String, ShortLink>) {
+        let mut conn = self.conn.clone();
+        let mut pipe = redis::pipe();
+        for (k, v) in keys {
+            if let Ok(json) = serde_json::to_string(&Self::to_serializable(&v)) {
+                pipe.set(k, json).ignore();
+            }
+        }
+        let _: redis::RedisResult<()> = pipe.query_async(&mut conn).await;
+    }
+}


### PR DESCRIPTION
## Summary
- add Redis object cache implementation
- expose redis module in cache
- include redis crate dependency

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_b_6846dbc1b974832080bea7a9a6897680