### PR TITLE
fix(auth): 修复CSRF cookie路径设置和错误消息格式

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.4.3] - 2026-02-01
+
+### 🎉 Release Highlights
+
+v0.4.3 是一次紧急修复版本：
+
+- **CSRF Cookie 路径修复** - 修复前端无法读取 CSRF cookie 导致所有变更操作（创建、修改、删除）返回 403 的问题
+
+### Fixed
+- **CSRF Cookie 路径问题** - 将 CSRF cookie 的 path 从 `admin_prefix` 改为 `/`
+  - 修复前端页面路径与 cookie path 不匹配时，所有 POST/PUT/DELETE 请求返回 403 Forbidden 的问题
+  - 确保任意 `admin_prefix` 配置下前端都能正常工作
+  - 安全性不受影响（`SameSite=Lax` 仍然生效）
+
 ## [v0.4.2] - 2026-02-01
 
 ### 🎉 Release Highlights
@@ -1034,7 +1048,8 @@ v0.3.0 是一个重大版本更新，包含大量安全增强、性能优化和�
 - Update README.md
 - Initial commit
 
-[Unreleased]: https://github.com/AptS-1547/shortlinker/compare/v0.4.2...HEAD
+[Unreleased]: https://github.com/AptS-1547/shortlinker/compare/v0.4.3...HEAD
+[v0.4.3]: https://github.com/AptS-1547/shortlinker/compare/v0.4.2...v0.4.3
 [v0.4.2]: https://github.com/AptS-1547/shortlinker/compare/v0.4.1...v0.4.2
 [v0.4.1]: https://github.com/AptS-1547/shortlinker/compare/v0.4.0...v0.4.1
 [v0.4.0]: https://github.com/AptS-1547/shortlinker/compare/v0.3.0...v0.4.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4248,7 +4248,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shortlinker"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "actix-cors",
  "actix-governor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shortlinker"
-version = "0.4.2"
+version = "0.4.3"
 description = "A minimalist URL shortener service supporting HTTP 307 redirection, built with Rust. Easy to deploy and lightning fast."
 authors = ["AptS-1547 <apts-1547@esaps.net>"]
 repository = "https://github.com/AptS-1547/shortlinker"

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ FROM scratch
 
 LABEL maintainer="AptS:1547 <apts-1547@esaps.net>"
 LABEL description="Shortlinker is a simple, fast, and secure URL shortener written in Rust."
-LABEL version="0.4.2"
+LABEL version="0.4.3"
 LABEL homepage="https://github.com/AptS-1547/shortlinker"
 LABEL license="MIT"
 

--- a/src/api/services/admin/auth.rs
+++ b/src/api/services/admin/auth.rs
@@ -56,7 +56,7 @@ impl KeyExtractor for LoginKeyExtractor {
                      Ensure nginx/proxy sets: proxy_set_header X-Forwarded-For $remote_addr;"
                 );
                 return Err(SimpleKeyExtractionError::new(
-                    "Unix Socket mode requires X-Forwarded-For header"
+                    "Unix Socket mode requires X-Forwarded-For header",
                 ));
             }
         }

--- a/src/api/services/admin/helpers.rs
+++ b/src/api/services/admin/helpers.rs
@@ -139,8 +139,8 @@ impl CookieBuilder {
     /// 构建 CSRF Cookie（非 HttpOnly，前端需要读取）
     pub fn build_csrf_cookie(&self, token: String) -> Cookie<'static> {
         let mut cookie = Cookie::new(constants::CSRF_COOKIE_NAME.to_string(), token);
-        // CSRF cookie path 与 admin_prefix 保持一致
-        cookie.set_path(self.admin_prefix.clone());
+        // CSRF cookie path 设置为 /，确保前端无论在哪个路由都能读取
+        cookie.set_path("/".to_string());
         // CSRF cookie 不能是 HttpOnly，因为前端 JS 需要读取它
         cookie.set_http_only(false);
         cookie.set_secure(self.secure);
@@ -159,8 +159,8 @@ impl CookieBuilder {
     /// 构建过期的 CSRF Cookie（登出时清除）
     pub fn build_expired_csrf_cookie(&self) -> Cookie<'static> {
         let mut cookie = Cookie::new(constants::CSRF_COOKIE_NAME.to_string(), String::new());
-        // CSRF cookie path 与 admin_prefix 保持一致
-        cookie.set_path(self.admin_prefix.clone());
+        // CSRF cookie path 设置为 /，确保前端无论在哪个路由都能读取
+        cookie.set_path("/".to_string());
         cookie.set_http_only(false);
         cookie.set_secure(self.secure);
         cookie.set_same_site(SameSite::Lax);

--- a/src/api/services/admin/helpers.rs
+++ b/src/api/services/admin/helpers.rs
@@ -140,7 +140,7 @@ impl CookieBuilder {
     pub fn build_csrf_cookie(&self, token: String) -> Cookie<'static> {
         let mut cookie = Cookie::new(constants::CSRF_COOKIE_NAME.to_string(), token);
         // CSRF cookie path 设置为 /，确保前端无论在哪个路由都能读取
-        cookie.set_path("/".to_string());
+        cookie.set_path("/");
         // CSRF cookie 不能是 HttpOnly，因为前端 JS 需要读取它
         cookie.set_http_only(false);
         cookie.set_secure(self.secure);
@@ -160,7 +160,7 @@ impl CookieBuilder {
     pub fn build_expired_csrf_cookie(&self) -> Cookie<'static> {
         let mut cookie = Cookie::new(constants::CSRF_COOKIE_NAME.to_string(), String::new());
         // CSRF cookie path 设置为 /，确保前端无论在哪个路由都能读取
-        cookie.set_path("/".to_string());
+        cookie.set_path("/");
         cookie.set_http_only(false);
         cookie.set_secure(self.secure);
         cookie.set_same_site(SameSite::Lax);


### PR DESCRIPTION
- 将CSRF cookie路径从admin_prefix改为根路径"/"，确保前端在所有路由都能正确读取
- 修复Unix Socket模式错误消息的逗号格式问题
- 更新admin-panel子模块引用