### PR TITLE
feat(config): 新增 StringArray 和 EnumArray 配置类型

### DIFF
--- a/src/config/definitions.rs
+++ b/src/config/definitions.rs
@@ -218,7 +218,7 @@ pub static ALL_CONFIGS: &[ConfigDef] = &[
     },
     ConfigDef {
         key: keys::API_TRUSTED_PROXIES,
-        value_type: ValueType::Json,
+        value_type: ValueType::StringArray,
         rust_type: RustType::VecString,
         default_fn: default_trusted_proxies,
         requires_restart: false,
@@ -399,7 +399,7 @@ pub static ALL_CONFIGS: &[ConfigDef] = &[
     },
     ConfigDef {
         key: keys::CORS_ALLOWED_ORIGINS,
-        value_type: ValueType::Json,
+        value_type: ValueType::StringArray,
         rust_type: RustType::VecString,
         default_fn: default_cors_allowed_origins,
         requires_restart: true,
@@ -410,7 +410,7 @@ pub static ALL_CONFIGS: &[ConfigDef] = &[
     },
     ConfigDef {
         key: keys::CORS_ALLOWED_METHODS,
-        value_type: ValueType::Json,
+        value_type: ValueType::EnumArray,
         rust_type: RustType::VecHttpMethod,
         default_fn: default_cors_allowed_methods,
         requires_restart: true,
@@ -421,7 +421,7 @@ pub static ALL_CONFIGS: &[ConfigDef] = &[
     },
     ConfigDef {
         key: keys::CORS_ALLOWED_HEADERS,
-        value_type: ValueType::Json,
+        value_type: ValueType::StringArray,
         rust_type: RustType::VecString,
         default_fn: default_cors_allowed_headers,
         requires_restart: true,

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -20,6 +20,10 @@ pub enum ValueType {
     Bool,
     Json,
     Enum,
+    /// 字符串数组类型，前端渲染为 Tag Input
+    StringArray,
+    /// 枚举数组类型，前端渲染为多选 Checkbox（需配合 enum_options）
+    EnumArray,
 }
 
 impl std::fmt::Display for ValueType {
@@ -30,6 +34,8 @@ impl std::fmt::Display for ValueType {
             Self::Bool => write!(f, "bool"),
             Self::Json => write!(f, "json"),
             Self::Enum => write!(f, "enum"),
+            Self::StringArray => write!(f, "stringarray"),
+            Self::EnumArray => write!(f, "enumarray"),
         }
     }
 }
@@ -43,6 +49,8 @@ impl std::str::FromStr for ValueType {
             "bool" => Ok(Self::Bool),
             "json" => Ok(Self::Json),
             "enum" => Ok(Self::Enum),
+            "stringarray" => Ok(Self::StringArray),
+            "enumarray" => Ok(Self::EnumArray),
             _ => Err(format!("Unknown value type: {}", s)),
         }
     }
@@ -82,6 +90,8 @@ mod tests {
         assert_eq!(ValueType::Bool.to_string(), "bool");
         assert_eq!(ValueType::Json.to_string(), "json");
         assert_eq!(ValueType::Enum.to_string(), "enum");
+        assert_eq!(ValueType::StringArray.to_string(), "stringarray");
+        assert_eq!(ValueType::EnumArray.to_string(), "enumarray");
     }
 
     #[test]
@@ -91,6 +101,14 @@ mod tests {
         assert_eq!("bool".parse::<ValueType>().unwrap(), ValueType::Bool);
         assert_eq!("json".parse::<ValueType>().unwrap(), ValueType::Json);
         assert_eq!("enum".parse::<ValueType>().unwrap(), ValueType::Enum);
+        assert_eq!(
+            "stringarray".parse::<ValueType>().unwrap(),
+            ValueType::StringArray
+        );
+        assert_eq!(
+            "enumarray".parse::<ValueType>().unwrap(),
+            ValueType::EnumArray
+        );
         assert!("invalid".parse::<ValueType>().is_err());
     }
 

--- a/src/config/validators.rs
+++ b/src/config/validators.rs
@@ -63,7 +63,14 @@ pub fn validate_config_value(key: &str, value: &str) -> Result<(), String> {
             let valid_values: Vec<&str> = options.iter().map(|o| o.value.as_str()).collect();
             return validate_enum_array(value, &valid_values);
         }
-        return Ok(());
+        // EnumArray 类型必须有 enum_options，如果没有说明配置定义有误
+        // 注意：由于 schema.rs 现在根据 RustType 自动推断 enum_options，
+        // 这个分支理论上不应该被触发（除非配置定义本身有问题）
+        return Err(format!(
+            "Internal error: EnumArray config '{}' is missing enum_options definition. \
+             Please check ConfigDef in definitions.rs",
+            key
+        ));
     }
 
     // Enum: 单值验证


### PR DESCRIPTION
- 在 ValueType 枚举中新增 StringArray 和 EnumArray 类型，用于表示字符串数组和枚举数组
- 更新 API_TRUSTED_PROXIES、CORS_ALLOWED_ORIGINS、CORS_ALLOWED_HEADERS 配置为 StringArray 类型
- 更新 CORS_ALLOWED_METHODS 配置为 EnumArray 类型
- 在验证器中添加对 StringArray 和 EnumArray 类型的验证逻辑
- StringArray 类型验证 JSON 数组格式，不验证内容
- EnumArray 类型验证数组元素是否在 enum_options 中
- 保持对旧 Json + enum_options 配置的向后兼容性

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

此 PR 为配置系统引入了两种新的值类型：`StringArray` 和 `EnumArray`，用于更精确地表达数组配置的语义。

**主要变更：**
- 在 `ValueType` 枚举中新增 `StringArray` 和 `EnumArray` 两种类型
- 更新 4 个配置项的类型定义：
  - `API_TRUSTED_PROXIES`、`CORS_ALLOWED_ORIGINS`、`CORS_ALLOWED_HEADERS` → `StringArray`
  - `CORS_ALLOWED_METHODS` → `EnumArray`
- 在验证器中实现针对新类型的验证逻辑，`StringArray` 只验证 JSON 格式，`EnumArray` 验证元素是否在枚举选项中
- 保持对旧 `Json + enum_options` 配置的向后兼容性
- 包含完整的单元测试覆盖

**代码质量：**
- 类型系统更加清晰，语义更明确
- 验证逻辑结构良好，职责分离清晰
- 测试覆盖全面，包括边界情况
- 向后兼容性处理得当

**影响范围：**
- 前端需要相应更新以支持新的值类型（已通过子模块更新体现）
- 数据库中现有配置值格式不变，无需迁移
- API 行为保持一致

<h3>Confidence Score: 5/5</h3>

- 此 PR 可以安全合并，代码质量高，测试覆盖完整
- 代码实现清晰规范，包含完整的类型定义、验证逻辑和单元测试。向后兼容性处理得当，不会影响现有功能。变更范围明确且可控，是一次高质量的重构
- 无文件需要特别关注

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/config/types.rs | 新增 StringArray 和 EnumArray 类型及其序列化/反序列化实现，包含完整的单元测试 |
| src/config/definitions.rs | 将 4 个 CORS 和 API 配置的类型从 Json 更新为 StringArray/EnumArray，语义更清晰 |
| src/config/validators.rs | 添加 StringArray 和 EnumArray 类型的验证逻辑，保持向后兼容，包含完整测试覆盖 |
| admin-panel | 子模块更新以支持新的配置类型 |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as 用户/前端
    participant API as API 端点
    participant Validator as validators.rs
    participant Schema as schema.rs
    participant Definitions as definitions.rs
    
    User->>API: 更新配置 (key, value)
    API->>Validator: validate_config_value(key, value)
    Validator->>Schema: get_schema(key)
    Schema->>Definitions: 查找 ConfigDef
    Definitions-->>Schema: 返回配置定义
    Schema-->>Validator: 返回 ConfigSchema (包含 value_type, enum_options)
    
    alt value_type == StringArray
        Validator->>Validator: 验证 JSON 字符串数组格式
        Note over Validator: 不验证数组内容<br/>接受任意字符串
    else value_type == EnumArray
        Validator->>Validator: 验证 JSON 数组格式
        Validator->>Validator: 检查每个元素是否在 enum_options 中
        Note over Validator: 大小写不敏感比较
    else value_type == Json + enum_options
        Note over Validator: 向后兼容逻辑
        Validator->>Validator: 按 EnumArray 方式验证
    else value_type == Enum
        Validator->>Validator: 验证单个值是否在 enum_options 中
    end
    
    Validator-->>API: 返回验证结果
    API-->>User: 返回成功/失败
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->