### PR TITLE
refactor(admin): 重构链接导入逻辑，统一到 LinkService

### DIFF
--- a/src/api/services/admin/analytics.rs
+++ b/src/api/services/admin/analytics.rs
@@ -363,6 +363,12 @@ pub async fn get_device_stats(
 const EXPORT_BATCH_SIZE: u64 = 10000;
 
 /// GET /admin/v1/analytics/export - 导出报告（流式响应）
+///
+/// 注意：此 handler 直接调用 storage.stream_click_logs_cursor()，
+/// 这是合理的例外，因为：
+/// 1. 流式操作的性能优化在 Storage 层完成
+/// 2. Service 层封装流式方法只是简单转发，无业务价值
+/// 3. 对于小数据量场景，可使用 AnalyticsService::export_click_logs()
 pub async fn export_report(
     _req: HttpRequest,
     query: web::Query<AnalyticsQuery>,

--- a/src/api/services/admin/types.rs
+++ b/src/api/services/admin/types.rs
@@ -279,16 +279,8 @@ pub struct ExportQuery {
     pub only_active: Option<bool>,
 }
 
-/// 导入模式
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, TS)]
-#[ts(export, export_to = TS_EXPORT_PATH)]
-#[serde(rename_all = "lowercase")]
-pub enum ImportMode {
-    #[default]
-    Skip, // 跳过已存在的
-    Overwrite, // 覆盖已存在的
-    Error,     // 遇到已存在的报错
-}
+// Re-export ImportMode from services layer for consistency
+pub use crate::services::ImportMode;
 
 /// 导入失败项
 #[derive(Serialize, Deserialize, Clone, Debug, TS)]

--- a/src/api/services/health.rs
+++ b/src/api/services/health.rs
@@ -20,6 +20,13 @@ pub struct AppStartTime {
     pub start_datetime: chrono::DateTime<chrono::Utc>,
 }
 
+/// Health Service
+///
+/// 注意：此 service 直接调用 storage 方法，不通过 LinkService。
+/// 这是合理的例外，因为：
+/// 1. 基础设施，需要简单直接（k8s probes 要求快速响应）
+/// 2. Storage 层方法已足够语义化（count, get_backend_config）
+/// 3. 健康检查不应依赖复杂的业务逻辑
 pub struct HealthService;
 
 impl HealthService {

--- a/src/api/services/redirect.rs
+++ b/src/api/services/redirect.rs
@@ -17,6 +17,13 @@ use crate::storage::{SeaOrmStorage, ShortLink};
 use crate::utils::ip::extract_client_ip;
 use crate::utils::is_valid_short_code;
 
+/// Redirect Service
+///
+/// 注意：此 service 直接操作 cache 和 storage，不通过 LinkService。
+/// 这是合理的例外，因为：
+/// 1. 热路径，性能关键（每秒数千次请求）
+/// 2. 逻辑已高度优化（Bloom → Negative → Object → DB）
+/// 3. Service 层封装会增加函数调用开销，难以内联优化
 pub struct RedirectService {}
 
 impl RedirectService {


### PR DESCRIPTION
- 将 admin/export_import.rs 中的 import_links 处理逻辑迁移到 LinkService::import_links_with_bloom
- 新增 ImportMode 类型导出到 TypeScript，保持前后端一致
- 在 analytics.rs、health.rs、redirect.rs 和 server.rs 中添加例外路径的文档说明
- 优化导入性能：使用 Bloom filter 预筛选减少数据库查询
- 统一错误处理和响应格式

close #100

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

本 PR 将链接导入逻辑从 `admin/export_import.rs` 重构到 `LinkService::import_links_with_bloom`，并添加了 Bloom filter 优化以减少数据库查询。

**主要变更：**
- 新增 `LinkService::import_links_with_bloom` 方法，使用 Bloom filter 预筛选存在性检查
- 将 `ImportMode` 从 admin types 移到 services 层，并导出到 TypeScript
- 为多个直接访问 storage 的路径添加了文档说明（export、redirect、health）

**发现的问题：**
- **数据丢失**：导入时丢失了 `created_at` 和 `click_count` 字段，所有导入的链接创建时间都会变成导入时刻，点击数归零
- **Overwrite 模式 bug**：CSV 内重复 code 可能导致 `batch_set` 失败，旧代码用 HashMap 去重，新代码用 Vec
- **可用性退化**：Service 层返回的错误信息无行号，用户无法定位具体哪行出错

**建议：**
修复数据丢失问题后再合并，否则会导致用户数据永久丢失。

<h3>Confidence Score: 1/5</h3>

- 存在严重的数据丢失 bug，不建议合并
- 导入功能会丢失 created_at 和 click_count 数据，这是核心功能的回归性 bug，会导致用户数据永久丢失。Overwrite 模式也可能因重复 code 失败。
- 重点关注 src/services/link_service.rs 和 src/api/services/admin/export_import.rs，需要修复数据丢失问题

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/services/link_service.rs | 新增 import_links_with_bloom 方法，但存在数据丢失问题：丢失 created_at 和 click_count 字段，且 Overwrite 模式下可能因 CSV 内重复 code 导致 batch_set 失败 |
| src/api/services/admin/export_import.rs | 重构为调用 LinkService，简化了代码，但引入了数据丢失和错误行号丢失问题 |
| src/api/services/admin/types.rs | 将 ImportMode 改为从 services 层重导出，保持类型一致性 |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as 客户端
    participant Handler as export_import.rs
    participant Service as LinkService
    participant Cache as Bloom Filter
    participant DB as Storage

    Client->>Handler: POST /admin/import (CSV文件)
    Handler->>Handler: 解析 CSV，验证空 code
    Handler->>Handler: 创建 ImportLinkItem 列表
    Handler->>Service: import_links_with_bloom(items, mode)
    
    Service->>Service: 验证 URL
    
    alt Skip/Error 模式
        loop 每个 code
            Service->>Cache: bloom_check(code)
            Cache-->>Service: true/false
        end
        Service->>DB: batch_check_codes_exist(maybe_exist)
        DB-->>Service: existing_codes
    end
    
    Service->>Service: 处理冲突（Skip/Error/Overwrite）
    Service->>Service: 解析 expires_at 和密码
    Service->>DB: batch_set(links_to_insert)
    DB-->>Service: Result
    
    loop 每个插入的链接
        Service->>Cache: update_cache(link)
    end
    
    Service-->>Handler: ImportResult
    Handler->>Handler: 合并错误信息（丢失行号）
    Handler-->>Client: ImportResponse
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->